### PR TITLE
Fix release CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,17 +36,23 @@ jobs:
         continue-on-error: true
         uses: crate-ci/typos@master
 
-      - name: Get Previous Release Tag
-        id: previous_release
-        continue-on-error: true
-        run: echo "tag=$(git describe --tags --abbrev=0)" >> "$GITHUB_OUTPUT"
+      - name: Get Latest Release
+        id: latest_release
+        run: |
+          tag="v$(jq -r .version package.json)"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          if [ "$(git ls-remote origin refs/tags/$tag)" ]; then
+            echo "released=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "released=0" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Checkout Previous Release
-        if: steps.previous_release.outputs.tag != ''
+        if: steps.latest_release.outputs.released == '1'
         uses: actions/checkout@v4
         with:
           path: previous-release
-          ref: ${{ steps.previous_release.outputs.tag }}
+          ref: ${{ steps.latest_release.outputs.tag }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -64,6 +70,7 @@ jobs:
         run: npm run test
 
       - name: Create Tokens Changeset
+        if: steps.latest_release.outputs.released == '1'
         run: npm run changeset-tokens
 
       - name: Create Release Pull Request or Publish to npm

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,13 +42,15 @@ jobs:
           tag="v$(jq -r .version package.json)"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           if [ "$(git ls-remote origin refs/tags/$tag)" ]; then
-            echo "released=1" >> "$GITHUB_OUTPUT"
+            echo "published=true" >> "$GITHUB_OUTPUT"
           else
-            echo "released=0" >> "$GITHUB_OUTPUT"
+            # Tag not found.
+            # This means that the current commit is a release commit that changes the package version.
+            echo "published=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Checkout Previous Release
-        if: steps.latest_release.outputs.released == '1'
+      - name: Checkout Latest Release
+        if: steps.latest_release.outputs.published == 'true'
         uses: actions/checkout@v4
         with:
           path: previous-release
@@ -70,7 +72,8 @@ jobs:
         run: npm run test
 
       - name: Create Tokens Changeset
-        if: steps.latest_release.outputs.released == '1'
+        # We must skip this process in a release commit, otherwise we will not be able to release.
+        if: steps.latest_release.outputs.published == 'true'
         run: npm run changeset-tokens
 
       - name: Create Release Pull Request or Publish to npm


### PR DESCRIPTION
There was a flaw in the process of detecting token differences and creating a changeset that it was also being generated in release commits.
In principle, release commits should be used for releases, but as a result of the changeset being generated here, PRs were being created instead of releases.

This PR checks whether the version currently in package.json has been released (whether it exists as a Git tag), and only generates a changeset if it has been released, thus resolving this issue.