### PR TITLE
DDS-1655 Add Original Tokens Studio Type If Available to JSON

### DIFF
--- a/.changeset/honest-files-admire.md
+++ b/.changeset/honest-files-admire.md
@@ -1,0 +1,5 @@
+---
+"@daikin-oss/dds-tokens": patch
+---
+
+Add Tokens Studio type to the tokens in the JSON outputs.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,6 @@ Import individual themes:
 
 There are JSON files under `json/` that lists the types and values of the tokens.
 These are basically for internal use and are used to integrate design tokens with Tailwind CSS.
-The structure of the JSON files is `{ "<token name>": ["<token value>", "<token type>"] }`.
+The structure of the JSON files is `{ "<token name>": ["<token value>", "<style-dictionary token type>", "<tokens-studio token type>" | null] }`.
 
 In addition, the theme JSON files before building, which are located in `themes/`, are also published in the same path in the package.

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -17,7 +17,11 @@ function jsonTokensFormatter({ dictionary }: Parameters<FormatFn>[0]): string {
       Object.fromEntries(
         dictionary.allTokens.map((token) => [
           token.name,
-          [String(token.value ?? "unknown"), token.type ?? "unknown"],
+          [
+            String(token.value ?? "unknown"),
+            token.type ?? "unknown",
+            token.$extensions?.["studio.tokens"]?.originalType ?? null,
+          ],
         ])
       ),
       null,


### PR DESCRIPTION
This PR adds a third item that represents a Tokens Studio original token type to the tuples in the JSON output.
This is necessary to make fine distinctions between tokens in the Tailwind CSS plugin.
This will not be a breaking change.