### PR TITLE
Make package.json importable

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "CHANGELOG.md"
   ],
   "exports": {
+    "./package.json": "./package.json",
     "./js/*.js": {
       "import": "./build/js/*.js",
       "require": "./build/js/*.cjs",


### PR DESCRIPTION
This change is not mandatory, but enabling the import of package.json makes it easier for users to retrieve the token version.
This is a common practice in modern npm packages.

- https://github.com/facebook/react/blob/v19.1.1/packages/react/package.json#L29
- https://github.com/vitejs/vite/blob/v7.1.5/packages/vite/package.json#L32