### PR TITLE
[DDS-3024] Fix `color.common.background.overlay` transparency

### DIFF
--- a/themes/dkn/dark/system.json
+++ b/themes/dkn/dark/system.json
@@ -173,7 +173,7 @@
           "type": "color"
         },
         "overlay": {
-          "value": "{color.black}",
+          "value": "#000000bf",
           "type": "color"
         }
       }

--- a/themes/dkn/light/system.json
+++ b/themes/dkn/light/system.json
@@ -173,7 +173,7 @@
           "type": "color"
         },
         "overlay": {
-          "value": "{color.black}",
+          "value": "#00000080",
           "type": "color"
         }
       }


### PR DESCRIPTION
It originally contained `color.black`, but the opacity was not set correctly. I set it to 50% for light mode and 75% for dark mode.